### PR TITLE
test(serialization): fix temporary file creation

### DIFF
--- a/test/utils/test_serialization.py
+++ b/test/utils/test_serialization.py
@@ -10,8 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from os import remove
-from tempfile import mkstemp
+import os
+from tempfile import TemporaryDirectory
 
 from numpy import array
 from pytest import mark, raises
@@ -47,15 +47,11 @@ from zne.utils.serialization import (
 )
 class TestDumpEncoder:
     def test_dump(self, obj, expected):
-        _, file_path = mkstemp()
-        try:
+        with TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "zne-dump")
             DumpEncoder.dump(obj, file=file_path)
-            contents = open(file_path).read()
-        finally:
-            try:
-                remove(file_path)
-            except PermissionError:
-                pass
+            with open(file_path) as f:
+                contents = f.read()
             assert contents == expected
 
     def test_dumps(self, obj, expected):

--- a/test/utils/test_serialization.py
+++ b/test/utils/test_serialization.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import os
+from os.path import join as join_path
 from tempfile import TemporaryDirectory
 
 from numpy import array
@@ -48,7 +48,7 @@ from zne.utils.serialization import (
 class TestDumpEncoder:
     def test_dump(self, obj, expected):
         with TemporaryDirectory() as tmpdir:
-            file_path = os.path.join(tmpdir, "zne-dump")
+            file_path = join_path(tmpdir, "zne-dump")
             DumpEncoder.dump(obj, file=file_path)
             with open(file_path) as f:
                 contents = f.read()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`mkstemp` is a way to create a temporary file securely, by avoiding race conditions.  It achieves this by not only returning the new file path, but also an open file descriptor to that file, so that you can be sure that you are writing to the file you intend to.  However, currently the file descriptor is being discarded.  I've fixed this to use `TemporaryDirectory` instead, which also has the benefit that it does its own cleanup.

### Details and comments

