### PR TITLE
feat(meta): allow bypassing ZNE on run

### DIFF
--- a/test/meta/test_run.py
+++ b/test/meta/test_run.py
@@ -36,14 +36,16 @@ class TestZNERun:
     ################################################################################
     ## TESTS
     ################################################################################
-    def test_base_run_no_zne_strategy(_self, self, run_options):
+    def test_base_run_noop_zne_strategy(_self, self, run_options):
         base_run = Mock()
         run = zne_run(base_run)
+        self.zne_strategy = ZNEStrategy(noise_factors=range(1, 4))
         _ = run(
             self,
             circuits="circuits",
             observables="observables",
             parameter_values="parameter_values",
+            zne_strategy=None,
             **run_options,
         )
         base_run.assert_called_once_with(

--- a/zne/meta/run.py
+++ b/zne/meta/run.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from types import EllipsisType
-from typing import cast
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.opflow import PauliSumOp
@@ -40,7 +38,7 @@ def zne_run(run: Callable) -> Callable:
         circuits: tuple[QuantumCircuit, ...],
         observables: tuple[BaseOperator | PauliSumOp, ...],
         parameter_values: tuple[tuple[float, ...], ...],
-        zne_strategy: ZNEStrategy | None | EllipsisType = ...,
+        zne_strategy: ZNEStrategy | None = ...,  # type: ignore
         **run_options,
     ) -> Job:
         # Strategy
@@ -50,7 +48,6 @@ def zne_run(run: Callable) -> Callable:
             zne_strategy = ZNEStrategy.noop()
         elif not isinstance(zne_strategy, ZNEStrategy):
             raise TypeError("Invalid zne_strategy object, expected ZNEStrategy.")
-        zne_strategy = cast(ZNEStrategy, zne_strategy)
 
         # ZNE
         target_num_experiments: int = len(circuits)

--- a/zne/meta/run.py
+++ b/zne/meta/run.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
+from types import EllipsisType
+from typing import cast
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.opflow import PauliSumOp
@@ -38,14 +40,17 @@ def zne_run(run: Callable) -> Callable:
         circuits: tuple[QuantumCircuit, ...],
         observables: tuple[BaseOperator | PauliSumOp, ...],
         parameter_values: tuple[tuple[float, ...], ...],
-        zne_strategy: ZNEStrategy | None = None,
+        zne_strategy: ZNEStrategy | None | EllipsisType = ...,
         **run_options,
     ) -> Job:
         # Strategy
-        if zne_strategy is None:
+        if zne_strategy is Ellipsis:
             zne_strategy = self.zne_strategy
+        elif zne_strategy is None:
+            zne_strategy = ZNEStrategy.noop()
         elif not isinstance(zne_strategy, ZNEStrategy):
             raise TypeError("Invalid zne_strategy object, expected ZNEStrategy.")
+        zne_strategy = cast(ZNEStrategy, zne_strategy)
 
         # ZNE
         target_num_experiments: int = len(circuits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Closes #6 


### Details and comments
Defaults are now accessed through `Ellipsis` (i.e. `...`), while passing `zne_strategy=None` triggers `ZNEStrategy.noop()`: effectively bypassing the ZNE functionality.
