### PR TITLE
fix(zne_strategy): remove caching since mutable

### DIFF
--- a/test/test_zne_strategy.py
+++ b/test/test_zne_strategy.py
@@ -354,25 +354,13 @@ class TestNoiseAmplification:
         circuit = QuantumCircuit(2)
         assert zne_strategy.amplify_circuit_noise(circuit, 1) == 0
         amplifier_mock.amplify_circuit_noise.assert_called_once_with(circuit, 1)
-        assert zne_strategy.amplify_circuit_noise(circuit, 1) == 0  # Check cache
         amplifier_mock.amplify_circuit_noise.reset_mock()
         assert zne_strategy.amplify_circuit_noise(circuit, 1.2) == 1
         amplifier_mock.amplify_circuit_noise.assert_called_once_with(circuit, 1.2)
-        assert zne_strategy.amplify_circuit_noise(circuit, 1.2) == 1  # Check cache
         circuit.h(0)
         amplifier_mock.amplify_circuit_noise.reset_mock()
         assert zne_strategy.amplify_circuit_noise(circuit, 2.4) == 2
         amplifier_mock.amplify_circuit_noise.assert_called_once_with(circuit, 2.4)
-        assert zne_strategy.amplify_circuit_noise(circuit, 2.4) == 2  # Check cache
-        # Overflow cache
-        CACHE_MAXSIZE = 256
-        for nf in range(CACHE_MAXSIZE):
-            expected = nf + 3
-            assert zne_strategy.amplify_circuit_noise(circuit, nf) == expected
-            if expected < CACHE_MAXSIZE:  # Check CACHE_MAXSIZE is correct
-                assert zne_strategy.amplify_circuit_noise(circuit, nf) == expected
-        assert zne_strategy.amplify_circuit_noise(circuit, nf) == CACHE_MAXSIZE + 3
-        assert zne_strategy.amplify_circuit_noise(circuit, nf) == CACHE_MAXSIZE + 3 + 1
 
     @mark.parametrize(
         "circuits, noise_factors",

--- a/zne/zne_strategy.py
+++ b/zne/zne_strategy.py
@@ -21,11 +21,10 @@ from warnings import warn
 from numpy import array
 from qiskit import QuantumCircuit
 from qiskit.primitives import EstimatorResult
-from qiskit.primitives.utils import _circuit_key
 
 from .extrapolation import Extrapolator, LinearExtrapolator
 from .noise_amplification import NoiseAmplifier, TwoQubitAmplifier
-from .types import EstimatorResultData, Metadata, RegressionDatum, ZNECache, ZNECacheKey
+from .types import EstimatorResultData, Metadata, RegressionDatum
 from .utils.grouping import from_common_key, group_elements_gen, merge_dicts
 from .utils.typing import isreal
 from .utils.validation import quality
@@ -168,7 +167,7 @@ class ZNEStrategy:
     ## NOISE AMPLIFICATION
     ################################################################################
     def amplify_circuit_noise(self, circuit: QuantumCircuit, noise_factor: float) -> QuantumCircuit:
-        """Cached noise amplification from :class:`~.noise_amplification.NoiseAmplifier`.
+        """Noise amplification from :class:`~.noise_amplification.NoiseAmplifier`.
 
         Args:
             circuit: The original quantum circuit.
@@ -177,19 +176,8 @@ class ZNEStrategy:
         Returns:
             The noise amplified quantum circuit
         """
-        # TODO: cached method when QuantumCircuit.__hash__ is implemented
-        if not hasattr(self, "_zne_cache"):
-            self._zne_cache: ZNECache = {}  # pylint: disable=attribute-defined-outside-init
-        CACHE_MAXSIZE = 256  # pylint: disable=invalid-name
-        zne_cache: ZNECache = self._zne_cache
-        cache_key: ZNECacheKey = (_circuit_key(circuit), noise_factor)
-        noisy_circuit: QuantumCircuit = zne_cache.get(cache_key, None)
-        if noisy_circuit is None:
-            noisy_circuit = self.noise_amplifier.amplify_circuit_noise(circuit, noise_factor)
-            # TODO: implement LRU (least recently used) functionality
-            if len(zne_cache) < CACHE_MAXSIZE:
-                zne_cache.update({cache_key: noisy_circuit})
-        return noisy_circuit
+        # TODO: caching
+        return self.noise_amplifier.amplify_circuit_noise(circuit, noise_factor)
 
     # TODO: decouple indexing logic depending on this method
     # TODO: add validation


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Removes caching functionality in `ZNEStrategy` since this class was made mutable in  its latest refactor.


### Details and comments
Fixes #14 
A more advanced caching technique should be added in the future.
