### PR TITLE
Pin `coverage < 7` when running `coveragepy-lcov`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveragepy-lcov
+          pip install tox coveragepy-lcov 'coverage<7'
       - name: Run coverage
         run: tox -e coverage
       - name: Convert to lcov


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

coverage 7.0.0 removed `FnmatchMatcher`, which coverage-lcov currently depends on.
The upstream issue is https://github.com/chaychoong/coveragepy-lcov/issues/5.

We can unpin this once coverage-lcov has been fixed.

### Details and comments

