### PR TITLE
feat(utils): add strategy class decorator

### DIFF
--- a/test/utils/test_strategy.py
+++ b/test/utils/test_strategy.py
@@ -301,22 +301,23 @@ def test_shared_strategy_ancestor(cls_A, cls_B, ancestor):
 ## STRATEGY CLASSES
 ################################################################################
 @mark.parametrize(
-    "init, namespace, settings",
+    "init, namespace",
     [
-        (lambda self: None, (), ()),
-        (lambda self, foo: None, ("foo",), ("foo",)),
-        (lambda self, _bar: None, ("_bar",), ()),
-        (lambda self, foo, _bar: None, ("foo", "_bar"), ("foo",)),
-        (lambda self, foo, bar: None, ("foo", "bar"), ("foo", "bar")),
-        (lambda self, _foo, _bar: None, ("_foo", "_bar"), ()),
+        (lambda self: None, ()),
+        (lambda self, foo: None, ("foo",)),
+        (lambda self, _bar: None, ("_bar",)),
+        (lambda self, foo, _bar: None, ("foo", "_bar")),
+        (lambda self, foo, bar: None, ("foo", "bar")),
+        (lambda self, _foo, _bar: None, ("_foo", "_bar")),
     ],
 )
 class TestStrategy:
     """Test Strategy class."""
 
     @mark.parametrize("cls_name", ["cls", "Class", "Klass"])
-    def test_init_subclass(self, cls_name, init, namespace, settings):
+    def test_init_subclass(self, cls_name, init, namespace):
         """Test subclassing logic."""
+        settings = tuple(n for n in namespace if not n.startswith("_"))
         cls = type(cls_name, (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
         obj = cls(**kwargs)
@@ -331,7 +332,7 @@ class TestStrategy:
         assert cls.SETTINGS_NAMESPACE is obj.SETTINGS_NAMESPACE
         assert cls.SETTINGS_NAMESPACE == tuple(settings)
 
-    def test_new(self, init, namespace, settings):
+    def test_new(self, init, namespace):
         """Test constructor logic."""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
@@ -339,7 +340,7 @@ class TestStrategy:
         assert hasattr(obj, "_original_args")
         assert obj._original_args == kwargs
 
-    def test_getattr(self, init, namespace, settings):
+    def test_getattr(self, init, namespace):
         """Test getattr."""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
@@ -350,7 +351,7 @@ class TestStrategy:
             with raises(AttributeError):
                 getattr(obj, attr)
 
-    def test_super_getattr(self, init, namespace, settings):
+    def test_super_getattr(self, init, namespace):
         """Test extending getattr."""
         _super = type("super", (), {"__getattr__": lambda self, attr: attr})
         cls = type("cls", (_BaseStrategy, _super), {"__init__": init})
@@ -361,8 +362,9 @@ class TestStrategy:
         for _, attr in enumerate(namespace):
             assert getattr(obj, attr) == attr
 
-    def test_repr(self, init, namespace, settings):
+    def test_repr(self, init, namespace):
         """Test string representation."""
+        settings = tuple(n for n in namespace if not n.startswith("_"))
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
         obj = cls(**kwargs)
@@ -371,11 +373,12 @@ class TestStrategy:
         str_repr = f"{cls_name}({settings_str})" if settings_str else cls_name
         assert str(obj) == repr(obj) == str_repr
 
-    def test_eq(self, init, namespace, settings):
+    def test_eq(self, init, namespace):
         """Test basic equality (same class, different settings).
 
         Note: checks reflexivity, symmetry, and transitivity.
         """
+        settings = tuple(n for n in namespace if not n.startswith("_"))
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
         obj = cls(**kwargs)
@@ -387,9 +390,10 @@ class TestStrategy:
             kwargs = {name: i + 1 for i, name in enumerate(namespace)}
             assert cls(**kwargs) != obj
 
-    def test_settings(self, init, namespace, settings):
+    def test_settings(self, init, namespace):
         """Test settings property."""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
+        settings = tuple(n for n in namespace if not n.startswith("_"))
         kwargs = {name: i for i, name in enumerate(namespace)}
         obj = cls(**kwargs)
         assert obj.settings == {n: i for i, n in enumerate(namespace) if n in settings}
@@ -398,7 +402,7 @@ class TestStrategy:
             assert obj.settings.get(n) == getattr(obj, n)
         assert obj.settings == {n: n for n in settings}
 
-    def test_init_args(self, init, namespace, settings):
+    def test_init_args(self, init, namespace):
         """Test init_args property."""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
@@ -409,7 +413,7 @@ class TestStrategy:
             assert obj.init_args.get(n) == getattr(obj, n)
         assert obj.init_args == {n: n for n in namespace}
 
-    def test_original_args(self, init, namespace, settings):
+    def test_original_args(self, init, namespace):
         """Test original_args property"""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}
@@ -417,7 +421,7 @@ class TestStrategy:
         assert obj.original_args == obj._original_args == kwargs
         assert obj.original_args is not obj._original_args
 
-    def test_replicate(self, init, namespace, settings):
+    def test_replicate(self, init, namespace):
         """Test replicate method."""
         cls = type("cls", (_BaseStrategy,), {"__init__": init})
         kwargs = {name: i for i, name in enumerate(namespace)}

--- a/test/utils/test_strategy.py
+++ b/test/utils/test_strategy.py
@@ -1,0 +1,457 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from unittest.mock import Mock
+
+from pytest import mark, raises
+
+from zne.utils.strategy import (
+    _closest_common_ancestor,
+    _FrozenStrategy,
+    _infer_init_namespace,
+    _infer_settings_namespace,
+    _is_facade,
+    _pack_init_args,
+    _shared_strategy_ancestor,
+    _Strategy,
+    strategy,
+)
+
+
+################################################################################
+## TEST CASES
+################################################################################
+def general_ancestry():
+    """Generate test cases for general common ancestry.
+
+    Returns:
+        A three-tuple holding the two classes to compare and the common ancestor class.
+    """
+    cls = type("cls", (), {})
+    clz = type("clz", (), {})
+    A = type("A", (cls,), {})
+    B = type("B", (cls,), {})
+    AA = type("AA", (A,), {})
+    AB = type("AB", (A,), {})
+    yield cls, int, object
+    yield cls, clz, object
+    yield cls, A, cls
+    yield A, B, cls
+    yield AA, B, cls
+    yield AA, AB, A
+
+
+def strategy_ancestry():
+    """Generate test cases for strategy common ancestry.
+
+    Returns:
+        A three-tuple holding the two classes to compare and the common strategy ancestor.
+    """
+    # TODO: _FrozenStrategy
+    NonStrategy = type("NonStrategy", (), {})
+    cls = type("cls", (_Strategy,), {})
+    clz = type("clz", (_Strategy,), {})
+    A = type("A", (cls,), {})
+    B = type("B", (cls,), {})
+    AA = type("AA", (A,), {})
+    AB = type("AB", (A,), {})
+    yield cls, int, None
+    yield cls, NonStrategy, None
+    yield cls, clz, None
+    yield cls, A, cls
+    yield A, B, cls
+    yield AA, B, cls
+    yield AA, AB, A
+
+
+def strategy_facades():
+    """Generate test cases for strategy facades.
+
+    Returns:
+        A three-tuple holding the two classes to compare and whether the former is
+        a facade of the latter.
+    """
+    NonStrategy = type("NonStrategy", (), {"__init__": lambda self, a, b: None})
+    cls = type("cls", (_Strategy,), {"__init__": lambda self, a, b: None})
+    clz = type("clz", (_Strategy,), {"__init__": lambda self, a, b: None})
+    subcls = type("subcls", (cls,), {"__init__": lambda self, a, b: None})
+    c_setting = type("c_setting", (cls,), {"__init__": lambda self, a, b, c: None})
+    c_arg = type("c_arg", (cls,), {"__init__": lambda self, a, b, _c: None})
+    A = type("A", (cls,), {"__init__": lambda self, a: None})
+    B = type("B", (cls,), {"__init__": lambda self, b: None})
+    C = type("C", (cls,), {"__init__": lambda self, c: None})
+    _C = type("_C", (cls,), {"__init__": lambda self, _c: None})
+    AA = type("AA", (A,), {"__init__": lambda self: None})
+    AB = type("AB", (A,), {"__init__": lambda self, a, b: None})
+    ABA = type("ABA", (AB,), {"__init__": lambda self, a: None})
+    CA = type("AA", (C,), {"__init__": lambda self: None})
+    yield NonStrategy, cls, False  # Non-strategy
+    yield clz, cls, False  # Different strategies
+    yield cls, cls, True  # Self facade
+    yield subcls, cls, True  # Same settings facade
+    yield c_setting, cls, False  # New setting
+    yield c_arg, cls, True  # New excluded
+    yield A, cls, True  # Simple facade
+    yield B, cls, True  # Other facade
+    yield C, cls, False  # Generalization
+    yield _C, cls, True  # Excluded arg
+    yield AA, cls, True  # Sub-facade
+    yield CA, cls, False  # Intermediate generalization
+    yield ABA, cls, False  # Local generalization
+
+
+################################################################################
+## CLASS DECORATOR
+################################################################################
+class TestClassDecorator:
+    """Test strategy class decorator."""
+
+    def test_new(self):
+        """Test new."""
+        decorator = strategy()
+        assert isinstance(decorator, strategy)
+        cls = type("cls", (), {})
+        decorator = strategy(cls)
+        assert not isinstance(decorator, strategy)
+        assert issubclass(decorator, cls)
+        assert issubclass(decorator, _Strategy)
+        assert not issubclass(decorator, _FrozenStrategy)
+        decorator = strategy(cls, frozen=True)
+        assert not isinstance(decorator, strategy)
+        assert issubclass(decorator, cls)
+        assert issubclass(decorator, _Strategy)
+        assert issubclass(decorator, _FrozenStrategy)
+
+    def test_init(self):
+        """Test init."""
+        decorator = strategy()
+        assert decorator.frozen is False
+        decorator = strategy(frozen=True)
+        assert decorator.frozen is True
+        decorator = strategy(frozen=False)
+        assert decorator.frozen is False
+
+    def test_call(self):
+        """Test call."""
+        decorator = strategy()
+        ## PLAIN STRATEGY
+        cls = type("cls", (), {})
+        strategy_class = decorator(cls)
+        assert issubclass(strategy_class, cls)
+        assert issubclass(strategy_class, _Strategy)
+        assert not issubclass(strategy_class, _FrozenStrategy)
+        assert strategy_class.__init__ is not object.__init__
+        strategy_class = decorator(cls, frozen=True)
+        assert issubclass(strategy_class, cls)
+        assert issubclass(strategy_class, _Strategy)
+        assert issubclass(strategy_class, _FrozenStrategy)
+        assert strategy_class.__init__ is not object.__init__
+        ## OVERRIDING INIT
+        init = lambda self: None
+        cls = type("cls", (), {"__init__": init})
+        assert decorator(cls).__init__ is init
+        ## OVERRIDING REPR
+        repr = lambda self: "STRATEGY-REPR"
+        cls = type("cls", (), {"__repr__": repr})
+        assert decorator(cls).__repr__ is repr
+        ## OVERRIDING EQ
+        eq = lambda self, other: self is other
+        cls = type("cls", (), {"__eq__": eq})
+        assert decorator(cls).__eq__ is eq
+        ## EXTENDING INIT SUBCLASS
+        super_call = Mock()
+        cls = type("cls", (), {"__init_subclass__": super_call})
+        _ = decorator(cls)
+        super_call.assert_called_once()
+        ## EXTENDING NEW
+        super_call = Mock()
+        cls = type("cls", (), {"__new__": super_call})
+        _ = decorator(cls)()
+        super_call.assert_called_once()
+        ## EXTENDING GETATTR
+        super_call = Mock()
+        cls = type("cls", (), {"__getattr__": super_call})
+        getattr(decorator(cls)(), "attr")
+        super_call.assert_called_once()
+
+    def test_frozen(self):
+        """Test frozen property."""
+        decorator = strategy()
+        assert decorator.frozen is False
+        decorator.frozen = True
+        assert decorator.frozen is True
+        decorator.frozen = False
+        assert decorator.frozen is False
+        decorator.frozen = 1
+        assert decorator.frozen is True
+        decorator.frozen = {}
+        assert decorator.frozen is False
+
+
+################################################################################
+## AUXILIARY
+################################################################################
+@mark.parametrize(
+    "init, kwargs",
+    [
+        (lambda self: None, {}),
+        (lambda self, a: None, {"a": 0}),
+        (lambda self, a, b: None, {"a": 0, "b": 1}),
+        (lambda self, a, b, c: None, {"a": 0, "b": 1, "c": 2}),
+    ],
+)
+def test_pack_init_args(init, kwargs):
+    """Test init args packing logic."""
+    cls = type("cls", (), {"__init__": init})
+    obj = cls(**kwargs)
+    assert _pack_init_args(obj, **kwargs) == kwargs  # keyword
+    assert _pack_init_args(obj, *kwargs.values()) == kwargs  # positional
+    if len(kwargs) > 1:
+        pos = tuple(v for v in tuple(kwargs.values())[: len(kwargs) // 2])
+        kw = {k: v for k, v in tuple(kwargs.items())[len(kwargs) // 2 :]}
+        assert _pack_init_args(obj, *pos, **kw) == kwargs  # positional + keyword
+
+
+@mark.parametrize(
+    "init, namespace",
+    [
+        (lambda self: None, ()),
+        (lambda self, a: None, ("a",)),
+        (lambda self, a, b: None, ("a", "b")),
+        (lambda self, a, b, c: None, ("a", "b", "c")),
+    ],
+)
+def test_infer_init_namesapce(init, namespace):
+    """Test init namespace inferance."""
+    cls = type("cls", (), {"__init__": init})
+    assert _infer_init_namespace(cls) == namespace
+
+
+@mark.parametrize(
+    "init, settings",
+    [
+        (lambda self: None, ()),
+        (lambda self, a: None, ("a",)),
+        (lambda self, _a: None, ()),
+        (lambda self, a, b: None, ("a", "b")),
+        (lambda self, a, _b: None, ("a",)),
+        (lambda self, _a, b: None, ("b",)),
+        (lambda self, _a, _b: None, ()),
+        (lambda self, a, _b, c: None, ("a", "c")),
+    ],
+)
+def test_infer_settings_namesapce(init, settings):
+    """Test settings namespace inferance."""
+    cls = type("cls", (), {"__init__": init})
+    assert _infer_settings_namespace(cls) == settings
+
+
+@mark.parametrize("cls_A, cls_B, ancestor", [*general_ancestry()])
+def test_closest_common_ancestor(cls_A, cls_B, ancestor):
+    """Test closest common ancestor retrieval."""
+    assert _closest_common_ancestor(cls_A, cls_B) is ancestor
+    assert _closest_common_ancestor(cls_B, cls_A) is ancestor
+    assert _closest_common_ancestor(cls_A(), cls_B) is ancestor
+    assert _closest_common_ancestor(cls_B, cls_A()) is ancestor
+    assert _closest_common_ancestor(cls_A, cls_B()) is ancestor
+    assert _closest_common_ancestor(cls_B(), cls_A) is ancestor
+    assert _closest_common_ancestor(cls_A(), cls_B()) is ancestor
+    assert _closest_common_ancestor(cls_B(), cls_A()) is ancestor
+
+
+@mark.parametrize("cls_A, cls_B, ancestor", [*strategy_ancestry()])
+def test_shared_strategy_ancestor(cls_A, cls_B, ancestor):
+    """Test strategy ancestor retrieval."""
+    assert _shared_strategy_ancestor(cls_A, cls_B) is ancestor
+    assert _shared_strategy_ancestor(cls_B, cls_A) is ancestor
+    assert _shared_strategy_ancestor(cls_A(), cls_B) is ancestor
+    assert _shared_strategy_ancestor(cls_B, cls_A()) is ancestor
+    assert _shared_strategy_ancestor(cls_A, cls_B()) is ancestor
+    assert _shared_strategy_ancestor(cls_B(), cls_A) is ancestor
+    assert _shared_strategy_ancestor(cls_A(), cls_B()) is ancestor
+    assert _shared_strategy_ancestor(cls_B(), cls_A()) is ancestor
+
+
+@mark.parametrize("cls, ancestor, expected", [*strategy_facades()])
+def test_is_facade(cls, ancestor, expected):
+    """Test strategy facade detection."""
+    assert _is_facade(cls, ancestor) is expected
+    if expected:  # Inverted is False
+        assert _is_facade(ancestor, cls) is (cls is ancestor)
+
+
+################################################################################
+## STRATEGY CLASSES
+################################################################################
+@mark.parametrize(
+    "init, namespace, settings",
+    [
+        (lambda self: None, (), ()),
+        (lambda self, foo: None, ("foo",), ("foo",)),
+        (lambda self, _bar: None, ("_bar",), ()),
+        (lambda self, foo, _bar: None, ("foo", "_bar"), ("foo",)),
+        (lambda self, foo, bar: None, ("foo", "bar"), ("foo", "bar")),
+        (lambda self, _foo, _bar: None, ("_foo", "_bar"), ()),
+    ],
+)
+class TestStrategy:
+    """Test Strategy class."""
+
+    @mark.parametrize("cls_name", ["cls", "Class", "Klass"])
+    def test_init_subclass(self, cls_name, init, namespace, settings):
+        """Test subclassing logic."""
+        cls = type(cls_name, (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        assert hasattr(cls, "NAME")
+        assert cls.NAME == obj.NAME == cls_name
+        assert hasattr(cls, "INIT_NAMESPACE")
+        assert isinstance(cls.INIT_NAMESPACE, tuple)
+        assert cls.INIT_NAMESPACE is obj.INIT_NAMESPACE
+        assert cls.INIT_NAMESPACE == tuple(namespace)
+        assert hasattr(cls, "SETTINGS_NAMESPACE")
+        assert isinstance(cls.SETTINGS_NAMESPACE, tuple)
+        assert cls.SETTINGS_NAMESPACE is obj.SETTINGS_NAMESPACE
+        assert cls.SETTINGS_NAMESPACE == tuple(settings)
+
+    def test_new(self, init, namespace, settings):
+        """Test constructor logic."""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        assert hasattr(obj, "_init_args")
+        assert obj._init_args == kwargs
+
+    def test_getattr(self, init, namespace, settings):
+        """Test getattr."""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        for n, attr in enumerate(namespace):
+            assert getattr(obj, attr) == n
+        for attr in ("non_attr", "error"):
+            with raises(AttributeError):
+                getattr(obj, attr)
+
+    def test_super_getattr(self, init, namespace, settings):
+        """Test extending getattr."""
+        _super = type("super", (), {"__getattr__": lambda self, attr: attr})
+        cls = type("cls", (_Strategy, _super), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        for attr in ("non_attr", "error"):
+            assert getattr(obj, attr) == attr
+        for _, attr in enumerate(namespace):
+            assert getattr(obj, attr) == attr
+
+    def test_repr(self, init, namespace, settings):
+        """Test string representation."""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        cls_name = cls.__name__
+        settings_str = ", ".join(f"{s}={getattr(obj, s)}" for s in settings)
+        str_repr = f"{cls_name}({settings_str})" if settings_str else cls_name
+        assert str(obj) == repr(obj) == str_repr
+
+    def test_eq(self, init, namespace, settings):
+        """Test basic equality (same class, different settings).
+
+        Note: checks reflexivity, symmetry, and transitivity.
+        """
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        copy = cls(**kwargs)
+        assert obj == obj  # Reflexivity
+        assert obj == copy == obj  # Symmetry
+        assert obj == copy == cls(**kwargs) == obj  # Transitivity
+        if settings:  # Different settings
+            kwargs = {name: i + 1 for i, name in enumerate(namespace)}
+            assert cls(**kwargs) != obj
+
+    def test_settings(self, init, namespace, settings):
+        """Test settings property."""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        assert obj.settings == {s: n for n, s in enumerate(namespace) if s in settings}
+        for s in settings:
+            setattr(obj, s, s)
+            assert obj.settings.get(s) == getattr(obj, s)
+        assert obj.settings == {s: s for s in settings}
+
+    def test_init_args(self, init, namespace, settings):
+        """Test init_args property"""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        assert obj.init_args == obj._init_args == kwargs
+        assert obj.init_args is not obj._init_args
+
+    def test_replicate(self, init, namespace, settings):
+        """Test replicate method."""
+        cls = type("cls", (_Strategy,), {"__init__": init})
+        kwargs = {name: i for i, name in enumerate(namespace)}
+        obj = cls(**kwargs)
+        updates_list = (
+            {},
+            {n: n for n in namespace},
+            {n: n for n, _ in zip(namespace, range(1))},
+            {n: n for n, _ in zip(namespace, range(2))},
+        )
+        for updates in updates_list:
+            replica = obj.replicate(**updates)
+            assert type(replica) is type(obj)
+            assert replica is not obj
+            (init_args := obj.init_args).update(**updates)
+            assert init_args == replica.init_args
+
+
+class TestStrategyNonParametric:
+    """Test Strategy class without parametrization."""
+
+    def test_eq_facade(self):
+        """Test equality for strategy facades.
+
+        Note: reflexivity assumed from `TestStrategy.test_eq`, symmetry always checked,
+        and transitivity checked where relevant (specified in comments).
+
+        Class-legend: {
+            N: {},
+            _Strategy: {
+                clz: {},
+                cls: {A: {}, B: {BB: {}}, C: {}, _C: {}}
+            }
+        }
+        """
+        cls = type("cls", (_Strategy,), {"__init__": lambda self, a, b: None})
+        clz = type("clz", (_Strategy,), {"__init__": lambda self, a, b: None})
+        A = type("A", (cls,), {"__init__": lambda self, a: None, "b": "b"})
+        B = type("B", (cls,), {"__init__": lambda self, b: None, "a": "a"})
+        BB = type("BB", (B,), {"__init__": lambda self, b: None, "a": "a"})
+        C = type("C", (cls,), {"__init__": lambda self, c: None, "a": "a", "b": "b"})
+        _C = type("_C", (cls,), {"__init__": lambda self, _c: None, "a": "a", "b": "b"})
+        N = type("N", (), {"__init__": lambda self, a, b: None})
+        assert cls("a", "b") == A("a") == cls("a", "b")  # Facade
+        assert cls("a", "b") == B("b") == cls("a", "b")  # Facade
+        assert A("a") == B("b") == A("a")  # Different facades (transitivity)
+        assert cls("a", "b") != cls("b", "a") != cls("a", "b")  # Different settings
+        assert cls("a", "a") != A("a") != cls("a", "a")  # Different settings
+        assert cls("a", "a") != B("b") != cls("a", "a")  # Different settings
+        assert A("b") != B("a") != A("b")  # Different facades different settings
+        assert cls("a", "b") != clz("a", "b") != cls("a", "b")  # Different strategies same settings
+        assert cls("a", "b") != N("a", "b") != cls("a", "b")  # Non-strategy
+        assert cls("a", "b") != C("c") != cls("a", "b")  # Non-facade
+        assert cls("a", "b") == _C("_c") == cls("a", "b")  # Excluded extra setting
+        assert cls("a", "b") == BB("b") == cls("a", "b")  # Sub-subclass
+        assert BB("b") == _C("_c") == BB("b")  # Furthest (transitivity)

--- a/test/utils/test_strategy.py
+++ b/test/utils/test_strategy.py
@@ -494,3 +494,33 @@ class TestStrategyNonParametric:
             assert ancestor.is_facade(obj) is expected
             assert ancestor_obj.is_facade(cls) is expected
             assert ancestor_obj.is_facade(obj) is expected
+
+    @mark.parametrize(
+        "init, error",
+        [
+            (lambda self: None, False),
+            (lambda self, /: None, False),
+            (lambda self, foo: None, False),
+            (lambda self, /, foo: None, False),
+            (lambda self, foo, /: None, True),
+            (lambda self, foo, /, bar: None, True),
+            (lambda self, foo, bar, /: None, True),
+            (lambda self, *args: None, True),
+            (lambda self, foo, *args: None, True),
+            (lambda self, foo, *args, bar: None, True),
+            (lambda self, foo, *, bar: None, False),
+            (lambda self, *, foo, bar: None, False),
+            (lambda self, **kwargs: None, True),
+            (lambda self, foo, **kwargs: None, True),
+            (lambda self, *, foo, **kwargs: None, True),
+            (lambda self, foo, *, bar, **kwargs: None, True),
+            (lambda self, *args, **kwargs: None, True),
+            (lambda self, foo, /, *args, **kwargs: None, True),
+        ],
+    )
+    def test_validate_init(self, init, error):
+        if error:
+            with raises(TypeError):
+                _ = type("cls", (_BaseStrategy,), {"__init__": init})
+        else:
+            _ = type("cls", (_BaseStrategy,), {"__init__": init})

--- a/test/utils/test_strategy.py
+++ b/test/utils/test_strategy.py
@@ -155,6 +155,18 @@ class TestClassDecorator:
         assert issubclass(strategy_class, _Strategy)
         assert issubclass(strategy_class, _FrozenStrategy)
         assert strategy_class.__init__ is not object.__init__
+        ## OVERRIDING MODULE
+        module = "MODULE"
+        cls = type("cls", (), {"__module__": module})
+        assert decorator(cls).__module__ is module
+        # OVERRIDING ANNOTATIONS
+        annotations = {"annotation": ...}
+        cls = type("cls", (), {"__annotations__": annotations})
+        assert decorator(cls).__annotations__ is annotations
+        ## OVERRIDING DOC
+        doc = "DOCSTRING"
+        cls = type("cls", (), {"__doc__": doc})
+        assert decorator(cls).__doc__ is doc
         ## OVERRIDING INIT
         init = lambda self: None
         cls = type("cls", (), {"__init__": init})
@@ -239,6 +251,7 @@ def test_infer_init_namesapce(init, namespace):
 @mark.parametrize(
     "init, settings",
     [
+        (object.__init__, ()),
         (lambda self: None, ()),
         (lambda self, a: None, ("a",)),
         (lambda self, _a: None, ()),

--- a/test/utils/test_strategy.py
+++ b/test/utils/test_strategy.py
@@ -154,6 +154,10 @@ class TestClassDecorator:
         assert issubclass(strategy_class, _BaseStrategy)
         assert issubclass(strategy_class, _FrozenStrategy)
         assert strategy_class.__init__ is not object.__init__
+        ## NAME
+        name = "NAME"
+        cls = type(name, (), {})
+        assert decorator(cls).__name__ is name
         ## OVERRIDING MODULE
         module = "MODULE"
         cls = type("cls", (), {"__module__": module})

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -153,9 +153,6 @@ class strategy:  # pylint: disable=invalid-name
             for attr in self.OVERRIDING_NAMESPACE
             if (value := target.__dict__.get(attr, UNSET)) is not UNSET
         }
-        print(target.__dict__)
-        print(overriding_attrs)
-        print()
         return type(target.__name__, (BaseStrategy, target), overriding_attrs)
 
     @property

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -1,0 +1,278 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Strategy design pattern tools.
+
+This module provides support for strategy classes, which are similar in format and
+spirit to those produced by the builtin :class:`dataclass` decorator. In this case,
+the relevant information is extracted from the class' ``__init__`` method signature
+rather than from class fields. Said class signature specifies the so called 'settings'
+for the strategy, where arguments whose name begins with a leading ``_`` are excluded
+from the settings namespace. Although not currently enforced, it is strongly suggested
+for these excluded arguments to be optional (i.e. developers should provide defaults).
+
+Construction-time arguments (including defaults) are referred to as 'init args', and
+are not subject to any namespace exclussions: they are merely a reflection of the values
+of all arguments passed to ``__init__`` when instantiating the given strategy object.
+
+Strategy classes include the following specific mehods and fields:
+    01. ``__init_subclass__``: to handle subclassing.
+    02. ``__new__``: to save the init args (i.e. initial settings) at construction-time.
+    03. ``__getattr__``: allows retrieving init args via ``getattr`` (i.e. virtual attrs).
+    04. ``__repr__``: a string representation of the strategy instance.
+    05. ``__eq__``: to compare strategy instances.
+    06. ``NAME``: the name of the strategy (i.e. class name).
+    07. ``INIT_NAMESPACE``: a tuple of the strategy's settings names.
+    08. ``SETTINGS_NAMESPACE``: a tuple of the strategy's settings names.
+    09. ``settings``: a dictionary of settings and their corresponding values/states.
+    10. ``init_args``: a copy of the construction-time init args.
+    11. ``replicate``: to build replicas of any strategy instance with updated settings.
+
+Out of these, {01, 02, 03} extend those found in the decorated class, and {04, 05}
+can be overriden; all others should be left unmodified.
+
+Classes inheriting from a :class:`strategy` class, are strategy classes
+themselves as well; with settings either inherited or provided by a new
+``__init__`` method. This means that they do not need to be re-decorated.
+
+Generally speaking, strategies are mutable, meaning that their settings
+can be updated at runtime. The implicit assumption made by this decorator is
+that the current state of all settings listed in ``SETTINGS_NAMESPACE`` can be
+accessed through a ``getattr`` call. If any of these settings is not accessible
+that way the corresponding (construction-time) init arg will be retrieved instead,
+possibly leading to conflicts and runtime errors if mutated after instantiation.
+If certain settings cannot be accessed by design, the suggested solution is
+removing said settings from the settings namespace as explained before, or adding a
+dummy property that retrieves their state (i.e. getter).
+
+Oftentimes, developers will need their strategies to be immutable after instantiation.
+To this end, the :class:`~zne.utils.strategy.strategy` decorator class accepts and
+optional keyword argument ``frozen`` which, if set to ``True`` (default ``False``),
+will forbid all ``setattr`` calls, and automatically return deepcopies of mutable
+settings. In this scenario, settings will still be declared through the class'
+``__init__`` method signature, while the body could be left blank (i.e. ``pass``),
+hold the appropriate docstring, or used for validation among other things.
+
+Replicas of any strategy instance can be produced by calling their
+:method:`~zne.utils.strategy.strategy.replicate` method with updated settings
+as keyword arguments. This is specially useful when dealing with frozen
+(i.e. immutable) strategies.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from inspect import signature
+from typing import Any
+
+from .classconstant import classconstant
+from .unset import UNSET
+
+
+################################################################################
+## CLASS DECORATOR
+################################################################################
+class strategy:  # pylint: disable=invalid-name
+    """Strategy class decorator."""
+
+    __slots__ = ("_frozen",)
+
+    def __new__(cls, /, target: type | None = None, **kwargs) -> type | strategy:  # type: ignore
+        """Return a decorated class or a strategy object capable of decorating."""
+        self = super().__new__(cls)
+        if target is None:
+            return self  # Note: init auto-triggered for `strategy` return types
+        return self(target, **kwargs)
+
+    def __init__(self, /, *_, frozen: bool = False, **__) -> None:
+        """Save decorator configuration."""
+        self.frozen: bool = frozen
+
+    def __call__(self, /, target: type, *, frozen: bool | None = None, **__) -> type:
+        """Decorate target class."""
+        frozen = self.frozen if frozen is None else frozen
+        BaseStrategy = _FrozenStrategy if frozen else _Strategy
+        overriding_attrs = {
+            attr: value
+            for attr in ("__repr__", "__eq__")
+            if (value := target.__dict__.get(attr, UNSET)) is not UNSET
+        }
+        if target.__init__ is object.__init__:  # type: ignore
+            overriding_attrs.update({"__init__": lambda self: None})
+        return type(target.__name__, (BaseStrategy, target), overriding_attrs)
+
+    @property
+    def frozen(self) -> bool:
+        """Frozen strategy."""
+        return getattr(self, "_frozen", False)
+
+    @frozen.setter
+    def frozen(self, value: bool) -> None:
+        self._frozen: bool = bool(value)
+
+
+################################################################################
+## AUXILIARY
+################################################################################
+def _pack_init_args(obj: object, *args, **kwargs) -> dict[str, Any]:
+    """Packs object init options as a dict, binding missing kwargs with defaults.
+
+    Args:
+        obj: the object whose `__init__` method to inspect.
+        args, kwargs: the particular values passed on to the `__init__` method.
+
+    Returns:
+        A dictionary sorted by signature, where keys are argument names,
+        and values are either those provided or the `__init__` defaults.
+
+    Note:
+        Dictionaries keep insertion order as a langauage feature from Python 3.7.
+        https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6#answers
+    """
+    init_signature = signature(obj.__init__)  # type: ignore
+    bound_signature = init_signature.bind(*args, **kwargs)
+    bound_signature.apply_defaults()
+    bound_args = bound_signature.arguments  # Note: type `OrderedDict`
+    return dict(bound_args)
+
+
+def _infer_init_namespace(cls: type) -> tuple[str, ...]:
+    """Infer init namespace from a given class."""
+    init_signature = signature(cls.__init__)  # type: ignore
+    parameters = init_signature.parameters.values()
+    namespace = tuple(map(lambda p: p.name, parameters))
+    return namespace[1:]  # Note: disregard `self`
+
+
+def _infer_settings_namespace(cls: type) -> tuple[str, ...]:
+    """Infer strategy settings namespace from a given class."""
+    if cls.__init__ is object.__init__:  # type: ignore
+        return ()  # Note: to avoid `*(*kw)args` from `object.__init__`
+    init_namespace: tuple[str, ...] = _infer_init_namespace(cls)
+    return tuple(name for name in init_namespace if not name.startswith("_"))
+
+
+def _closest_common_ancestor(*args) -> type:
+    """Retrieve closest common ancestor class from the input classes' MROs.
+
+    Note: metaclasses are not supported, ``object`` is always shared.
+    """
+    cls_list = map(lambda obj: obj if isinstance(obj, type) else type(obj), args)
+    mros = [cls.mro() for cls in cls_list]
+    base = min(mros, key=len)
+    mros.remove(base)
+    for cls in base:
+        if all(cls in mro for mro in mros):
+            return cls
+    return None  # Note: safeguard, `object` always shared (never called)  # pragma: no cover
+
+
+def _shared_strategy_ancestor(*strategies) -> type | None:
+    """Return closest common strategy ancestor or None."""
+    shared: type = _closest_common_ancestor(*strategies)
+    if shared in (None, _Strategy, _FrozenStrategy) or not issubclass(shared, _Strategy):
+        return None
+    return shared
+
+
+def _is_facade(strategy: Any, ancestor: type) -> bool:  # pylint: disable=redefined-outer-name
+    """Checks if the input strategy is a facade of the given ancestor class.
+
+    Note: Facades must be subclasses.
+    """
+    if not isinstance(strategy, type):
+        strategy = type(strategy)
+    if not (issubclass(strategy, ancestor) and issubclass(ancestor, _Strategy)):
+        return False  # Note: subclassing is transitive (A -> B -> C then A -> C)
+    filtered_mro = list(filter(lambda cls: issubclass(cls, ancestor), strategy.mro()))
+    for cls, parent in zip(filtered_mro, filtered_mro[1:]):
+        if set(cls.SETTINGS_NAMESPACE) - set(parent.SETTINGS_NAMESPACE):
+            return False
+    return True
+
+
+################################################################################
+## STRATEGY CLASSES
+################################################################################
+class _Strategy:
+    """Stretegy class.
+
+    Note: this class is not meant to be instantiated or inherited directly,
+    it has to be applied through the ``strategy`` class decorator.
+    """
+
+    # TODO: subscriptable classconstant types (e.g. `classconstant[str]`)
+    NAME: classconstant  # str
+    INIT_NAMESPACE: classconstant  # tuple[str]
+    SETTINGS_NAMESPACE: classconstant  # tuple[str]
+
+    def __init_subclass__(cls, *args, **kwargs) -> None:
+        super().__init_subclass__(*args, **kwargs)
+        cls.NAME = classconstant(cls.__name__)
+        cls.INIT_NAMESPACE = classconstant(_infer_init_namespace(cls))
+        cls.SETTINGS_NAMESPACE = classconstant(_infer_settings_namespace(cls))
+
+    def __new__(cls, *args, **kwargs) -> _Strategy:
+        # Note: logic added to `__new__` to avoid making `super().__init__` mandatory
+        self = super().__new__(cls)
+        self._init_args = _pack_init_args(self, *args, **kwargs)  # type: ignore
+        return self
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return super().__getattr__(name)  # type: ignore
+        except (AttributeError, TypeError):
+            init_args = getattr(self, "_init_args", {})
+            attr = init_args.get(name, UNSET)
+        if attr is UNSET:
+            raise AttributeError(f"'{type(self)}' object has no attribute '{name}'")
+        return deepcopy(attr)
+
+    def __repr__(self) -> str:
+        strategy_name: str = type(self).__name__
+        settings_str = ", ".join(f"{key}={value!r}" for key, value in self.settings.items())
+        return f"{strategy_name}({settings_str})" if settings_str else strategy_name
+
+    def __eq__(self, other: object) -> bool:
+        shared: type | None = _shared_strategy_ancestor(self, other)
+        if shared is None or not _is_facade(self, shared) or not _is_facade(other, shared):
+            return False
+        SHARED_NAMESPACE = shared.SETTINGS_NAMESPACE  # type: ignore # pylint: disable=invalid-name
+        self_settings = {name: getattr(self, name, UNSET) for name in SHARED_NAMESPACE}
+        other_settings = {name: getattr(other, name, UNSET) for name in SHARED_NAMESPACE}
+        return self_settings == other_settings
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        """Strategy settings."""
+        return {key: getattr(self, key) for key in self.SETTINGS_NAMESPACE}
+
+    @property
+    def init_args(self) -> dict[str, Any]:
+        """A copy of init args."""
+        init_args = getattr(self, "_init_args", {})
+        return deepcopy(init_args)
+
+    def replicate(self, **kwargs) -> _Strategy:
+        """Build a replica of the current strategy altering the specified settings."""
+        init_args = {key: deepcopy(getattr(self, key)) for key in self.INIT_NAMESPACE}
+        init_args.update(kwargs)
+        return type(self)(**init_args)
+
+
+# TODO
+class _FrozenStrategy(_Strategy):
+    """Frozen (immutable) strategy class.
+
+    Note: this class is not meant to be instantiated or inherited directly,
+    it has to be applied through the ``strategy`` class decorator.
+    """

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -195,8 +195,7 @@ def _pack_init_args(obj: object, *args, **kwargs) -> dict[str, Any]:
 def _infer_init_namespace(cls: type) -> tuple[str, ...]:
     """Infer init namespace from a given class."""
     init_signature = signature(cls.__init__)  # type: ignore
-    parameters = init_signature.parameters.values()
-    namespace = tuple(map(lambda p: p.name, parameters))
+    namespace = tuple(init_signature.parameters.keys())
     return namespace[1:]  # Note: disregard `self`
 
 

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -39,8 +39,8 @@ Strategy classes include the following specific mehods and fields:
     11. ``original_args``: a copy of the construction-time init args.
     12. ``replicate``: to build replicas of any strategy instance with updated settings.
 
-Out of these, {01, 02, 03} extend those found in the decorated class, and {04, 05}
-can be overriden; all others should be left unmodified.
+Out of these, {01, 02, 03} can extend and be extended, and {04, 05} can be overriden;
+all others should be left unmodified.
 
 Classes inheriting from a :class:`strategy` class, are strategy classes
 themselves as well; with settings either inherited or provided by a new
@@ -84,7 +84,41 @@ from .unset import UNSET
 ## CLASS DECORATOR
 ################################################################################
 class strategy:  # pylint: disable=invalid-name
-    """Strategy class decorator."""
+    """Strategy class decorator.
+
+    Applies a strategy base class and its corresponding methods to the decorated class.
+
+    This is done by dynmically subclassing from both the correspoding strategy base class
+    (i.e. mutable or frozen), and the pre-decorated class as declared by the developer.
+    The base strategy class will have precedence in the resulting class' mro; therefor,
+    the resulting strategy class will extend the ``__init_subclass__``, ``__new__``, and
+    ``__getattr__`` methods from the pre-decorated class. Also, in order to allow
+    redefinition of the base strategy class' ``__repr__`` and ``__eq__`` methods, if found
+    in the pre-decorated class, they will be bridged to the resulting class; efectively
+    overriding the defaults.
+
+    Args:
+        frozen: Whether to inherit from ``_Strategy`` or ``_FrozenStrategy``.
+
+    Example:
+        >>> @strategy
+        >>> class cls:
+        >>>     def __init__(self, a, b, _c=None):
+        >>>         pass
+        >>> cls.mro()
+        [zne.utils.strategy.cls, zne.utils.strategy._Strategy, __main__.cls, object]
+
+        >>> @strategy(frozen=True)
+        >>> class cls:
+        >>>     def __init__(self, a, b, _c=None):
+        >>>         pass
+        >>> cls.mro()
+        [zne.utils.strategy.cls,
+        zne.utils.strategy._FrozenStrategy,
+        zne.utils.strategy._Strategy,
+        __main__.cls,
+        object]
+    """
 
     __slots__ = ("_frozen",)
 

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -27,7 +27,7 @@ to ``__init__`` when instantiating the given strategy object.
 
 Currently, init arguments of kind POSITIONAL_ONLY, VAR_POSITIONAL, and VAR_KEYWORD
 are disallowed. See https://docs.python.org/3/library/inspect.html#inspect.Parameter.kind
-fpr more information.
+for more information.
 
 Strategy classes include the following specific mehods and fields:
     01. ``__init_subclass__``: to handle subclassing.

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -181,7 +181,7 @@ def _closest_common_ancestor(*args) -> type:
 def _shared_strategy_ancestor(*strategies) -> type | None:
     """Return closest common strategy ancestor or None."""
     shared: type = _closest_common_ancestor(*strategies)
-    if shared in (None, _Strategy, _FrozenStrategy) or not issubclass(shared, _Strategy):
+    if shared in (None, *_BASE_STRATEGY_CLASSES) or not issubclass(shared, _Strategy):
         return None
     return shared
 
@@ -203,7 +203,7 @@ def _is_facade(strategy: Any, ancestor: type) -> bool:  # pylint: disable=redefi
 
 
 ################################################################################
-## STRATEGY CLASSES
+## BASE STRATEGY CLASSES
 ################################################################################
 class _Strategy:
     """Stretegy class.
@@ -281,3 +281,6 @@ class _FrozenStrategy(_Strategy):
 
     Note: this class is not meant to be instantiated or inherited directly.
     """
+
+
+_BASE_STRATEGY_CLASSES = {_Strategy, _FrozenStrategy}

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -72,6 +72,7 @@ as keyword arguments. This is specially useful when dealing with frozen
 
 from __future__ import annotations
 
+from abc import ABC
 from copy import deepcopy
 from inspect import signature
 from typing import Any
@@ -122,7 +123,7 @@ class strategy:  # pylint: disable=invalid-name
         object]
     """
 
-    __slots__ = ("_frozen",)
+    __slots__ = ("_frozen",)  # TODO: add `abstract` option
 
     OVERRIDING_NAMESPACE = (
         "__module__",
@@ -249,7 +250,7 @@ def _is_facade(strategy: Any, ancestor: type) -> bool:  # pylint: disable=redefi
 ## BASE STRATEGY CLASSES
 ################################################################################
 class _BaseStrategy:
-    """Base stretegy class.
+    """Strategy base class.
 
     Note: this class is not meant to be instantiated or inherited directly.
     """
@@ -322,11 +323,27 @@ class _BaseStrategy:
 
 
 # TODO
-class _FrozenStrategy(_BaseStrategy):
-    """Frozen (immutable) base strategy class.
+class _BaseStrategyABC(_BaseStrategy, ABC):
+    """Strategy abstract base class.
 
     Note: this class is not meant to be instantiated or inherited directly.
     """
 
 
-_BASE_STRATEGY_CLASSES = {_BaseStrategy, _FrozenStrategy}
+# TODO
+class _FrozenStrategy(_BaseStrategy):
+    """Frozen (immutable) strategy base class.
+
+    Note: this class is not meant to be instantiated or inherited directly.
+    """
+
+
+# TODO
+class _FrozenStrategyABC(_FrozenStrategy, ABC):
+    """Frozen (immutable) strategy abstract base class.
+
+    Note: this class is not meant to be instantiated or inherited directly.
+    """
+
+
+_BASE_STRATEGY_CLASSES = {_BaseStrategy, _BaseStrategyABC, _FrozenStrategy, _FrozenStrategyABC}

--- a/zne/utils/strategy.py
+++ b/zne/utils/strategy.py
@@ -57,7 +57,7 @@ removing said settings from the settings namespace as explained before, or addin
 dummy property that retrieves their state (i.e. getter).
 
 Oftentimes, developers will need their strategies to be immutable after instantiation.
-To this end, the :class:`~zne.utils.strategy.strategy` decorator class accepts and
+To this end, the :class:`~zne.utils.strategy.strategy` decorator class accepts an
 optional keyword argument ``frozen`` which, if set to ``True`` (default ``False``),
 will forbid all ``setattr`` calls, and automatically return deepcopies of mutable
 settings. In this scenario, settings will still be declared through the class'
@@ -66,7 +66,7 @@ hold the appropriate docstring, or used for validation among other things.
 
 Replicas of any strategy instance can be produced by calling their
 :method:`~zne.utils.strategy.strategy.replicate` method with updated settings
-as keyword arguments. This is specially useful when dealing with frozen
+as keyword arguments. This is especially useful when dealing with frozen
 (i.e. immutable) strategies.
 """
 
@@ -89,16 +89,16 @@ class strategy:  # pylint: disable=invalid-name
 
     Applies a strategy base class and its corresponding methods to the decorated class.
 
-    This is done by dynmically subclassing from both the correspoding strategy base class
+    This is done by dynamically subclassing from both the corresponding strategy base class
     (i.e. mutable or frozen), and the pre-decorated class as declared by the developer.
-    The base strategy class will have precedence in the resulting class' mro; therefor,
+    The base strategy class will have precedence in the resulting class' mro; therefore,
     the resulting strategy class will extend the ``__init_subclass__``, ``__new__``, and
     ``__getattr__`` methods from the pre-decorated class. Additionally, in order to allow
     redefinition of the base strategy class' ``__init__`` (dummy), ``__repr__`` and ``__eq__``
-    methods, if found in the pre-decorated class, they will be bridged to the resulting class;
-    efectively overriding the defaults. Similarly, ``__module__``, ``__name__``,
-    ``__annotations__``, and ``__doc__``, will also be bridged from the pre-decorated class
-    as is standard in decorators.
+    methods, if these are found in the pre-decorated class' dictionary, they will be bridged
+    to the resulting class; effectively overriding the defaults. Similarly, ``__module__``,
+    ``__name__``, ``__annotations__``, and ``__doc__``, will also be bridged from the
+    pre-decorated class as is standard in decorators.
 
     Args:
         frozen: Whether to inherit from ``_BaseStrategy`` or ``_FrozenStrategy``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
A `strategy` class decorator and related strategy design pattern tools.


### Details and comments
The standard way of using the `strategy` class decorator is:
```python
from zne.utils.strategy import strategy

@strategy
class Klass:
    """Example class."""
    def __init__(self, stg_1, stg_2, _excluded_stg=...):
        ...

obj = Klass("foo", "bar")
print(f"NAME: {obj.NAME}")
print(f"INIT NAMESPACE: {obj.INIT_NAMESPACE}")
print(f"SETTINGS NAMESAPCE: {obj.SETTINGS_NAMESPACE}")
print(f"SETTINGS: {obj.settings}")
print(f"INIT ARGS: {obj.init_args}")
print(f"REPR: {obj}")

replica = obj.replicate(stg_2="no-bar")
print(f"REPLICA: {replica}")
```

Which outputs:
```
NAME: Klass
INIT NAMESPACE: ('stg_1', 'stg_2', '_excluded_stg')
SETTINGS NAMESAPCE: ('stg_1', 'stg_2')
SETTINGS: {'stg_1': 'foo', 'stg_2': 'bar'}
INIT ARGS: {'stg_1': 'foo', 'stg_2': 'bar', '_excluded_stg': Ellipsis}
REPR: Klass(stg_1='foo', stg_2='bar')
REPLICA: Klass(stg_1='foo', stg_2='no-bar')
```

Additionally, frozen strategy classes are also supported via:
```python
from zne.utils.strategy import strategy

@strategy(frozen=True)
class Klass:
    """Example class."""
    def __init__(self, stg_1, stg_2, _excluded_stg=...):
        ...
```

Other niceties like subclassing support, and `__eq__` comparison based on `type` and `settings` (with support for subclasses and strategy facades) is also implemented. 