### PR TITLE
perf(folding_amplifier): remove unecessary barriers in folded circuits

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -201,6 +201,14 @@ Currently, noise amplification is performed before [transpilation](https://qiski
 
 In a future release, noise amplification will be performed after transpilation by default, such that all base instructions in the circuit are folded by the correct amount whenever the noise factor is not an odd integer. However, there might be use cases where noise amplification before transpilation is preferred. For example, one might want to locally fold a user-defined instruction that consists of several basis gates (e.g. a Pauli twirling sequence). In these cases, one should specify that noise amplification needs to be performed before transpilation.
 
+When randomly sub-folding (i.e. partial-folding) gates in global folding, these gates may simplify more than what we aimed at with the selected noise factor, leading to inaccuracies in the noise amplification process. Similarly, they may simplify less, meaning that the original and inverse circuits simplify more than the partial folding, hence leading to an over-representation of the noise.
+
+There are three solutions for this:
+
+1. Inserting gates everywhere to avoid any simplification whatsoever. This is avoided as it would prevent gate simplification altogether, raising the baseline noise, reaching noise saturation earlier, and decreasing the effectiveness of the entire mitigation process.
+2. Making a randomness assumption and stating that, _on average_, the simplification on the partial and full foldings will be roughly the same quantitatively.
+3. Performing noise amplification after the simplification (i.e. optimization) process in the transpilation pipeline.
+
 ### Non-exact noise factors
 Certain noise amplifiers cannot reach the exact noise factors requested by the user, and will approximate them the best they can. If this approximation is not good enough (according to a tunable tolerance), a warning will be raised. Extrapolation though, will be performed based on the requested noise factors, instead of the approximated ones, which might result in inaccuracies. As of the current implementation, there is no way to retrieve the actual noise factors.
 

--- a/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
+++ b/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
@@ -15,7 +15,6 @@ from unittest.mock import Mock, patch
 
 from numpy.random import Generator, default_rng
 from pytest import fixture, mark, raises, warns
-from qiskit.circuit.random import random_circuit
 
 from zne.noise_amplification.folding_amplifier.global_folding_amplifier import (
     GlobalFoldingAmplifier,
@@ -221,14 +220,3 @@ class TestFoldingAmplifier:
     def test_compute_folding_no_foldings(self, NoiseAmplifier):
         with warns(UserWarning):
             assert NoiseAmplifier()._compute_folding_nums(3, 0) == (0, 0)
-
-    @mark.parametrize("seed", range(5))
-    def test_insert_barriers(self, NoiseAmplifier, seed):
-        circuit = random_circuit(2, 2, seed=seed).decompose(reps=1)
-        barrier_circuit = NoiseAmplifier._insert_barriers(circuit)
-        operations = iter(barrier_circuit)
-        for instruction, qargs, cargs in circuit:
-            assert (instruction, qargs, cargs) == next(operations)
-            barrier, barrier_qargs, _ = next(operations)
-            assert barrier.name == "barrier"
-            assert barrier_qargs == qargs

--- a/zne/noise_amplification/folding_amplifier/folding_amplifier.py
+++ b/zne/noise_amplification/folding_amplifier/folding_amplifier.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from warnings import warn
 
 from numpy.random import Generator, default_rng
-from qiskit.circuit import QuantumCircuit
 
 from ...utils.typing import isreal
 from ..noise_amplifier import CircuitNoiseAmplifier
@@ -153,13 +152,3 @@ class FoldingAmplifier(CircuitNoiseAmplifier):
             )
         num_full_foldings, num_sub_foldings = divmod(num_foldings, num_instructions)
         return num_full_foldings, num_sub_foldings
-
-    # TODO: `QuantumCircuit.insert_barriers_everywhere()`
-    @staticmethod
-    def _insert_barriers(circuit: QuantumCircuit) -> QuantumCircuit:
-        """Insert barriers between every instruction to avoid simplification."""
-        barrier_circuit = circuit.copy_empty_like()  # TODO: avoid copying
-        for instrunction, qargs, cargs in circuit:
-            barrier_circuit.append(instrunction, qargs, cargs)
-            barrier_circuit.barrier(qargs)
-        return barrier_circuit

--- a/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
+++ b/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
@@ -153,7 +153,7 @@ class LocalFoldingAmplifier(FoldingAmplifier):
         noisy_circuit = circuit.copy_empty_like()
         for operation, num_foldings in zip(circuit, foldings):
             noisy_circuit = self._append_folded(noisy_circuit, operation, num_foldings)
-        return self._insert_barriers(noisy_circuit)
+        return noisy_circuit
 
     def _build_foldings_per_gate(self, circuit: QuantumCircuit, noise_factor: float) -> list[int]:
         """Returns number of foldings for each gate in the circuit.
@@ -237,16 +237,19 @@ class LocalFoldingAmplifier(FoldingAmplifier):
             noise_factor: The corresponding noise factor.
 
         Returns:
-            The updated noisy cirucit.
+            The updated noisy circuit.
         """
         # TODO: Create FoldableCircuit class extending QuantumCircuit
         # TODO: CircuitInstruction.inverse()
         self._validate_num_foldings(num_foldings)
         instruction, qargs, cargs = operation
+        noisy_circuit.barrier(qargs)
         noisy_circuit.append(instruction, qargs, cargs)
         if num_foldings > 0:
+            noisy_circuit.barrier(qargs)
             noisy_circuit.append(instruction.inverse(), qargs, cargs)
-            noisy_circuit = self._append_folded(noisy_circuit, operation, num_foldings - 1)
+            return self._append_folded(noisy_circuit, operation, num_foldings - 1)
+        noisy_circuit.barrier(qargs)
         return noisy_circuit
 
     @staticmethod


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Folded circuits used to include barriers between all gates to avoid simplification during transpilation, which would cripple the noise amplification process. Some of those simplifications, nonetheless, could be safely performed without damaging our ability to controllably amplify noise (e.g. in global folding, when folding only a selection of gates locally). Therefore such a restrictive barrier structure raises the baseline noise, reaches noise saturation earlier, and decreases the effectiveness of the entire mitigation process.

This PR removes all unnecessary barriers from the folded circuits, keeping only those strictly necessary for the noise amplification process.

### Details and comments
When randomly sub-folding (i.e. partial-folding) gates in global folding, these gates may simplify more than what we aimed at with the selected noise factor, leading to inaccuracies in the noise amplification process. Similarly, they may simplify less, meaning that the original and inverse circuits simplify more than the partial folding, hence leading to an over-representation of the noise.

There are three solutions for this:
1. Inserting gates everywhere to avoid any simplification whatsoever. This was the original approach now reverted for the reasons indicated above.
2. Making a randomness assumption and stating that _on average_ the simplification on the partial and full foldings will be roughly the same.
3. Performing noise amplification after the simplification (i.e. optimization) process in the transpilation pipeline.