### PR TITLE
refactor: discontinue using isint from typing utils module

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+from collections.abc import Iterable
+
 from zne import __version__
 
 
@@ -30,18 +32,18 @@ TYPES = [
     STR := "0",
     BOOL := True,
     NONE := None,
-    LST := [0],
-    TPL := (0,),
+    LIST := [0],
+    TUPLE := (0,),
     DICT := {0: 0},
 ]
-NO_INTS = [t for t in TYPES if type(t) != type(INT)]
-NO_NONE = [t for t in TYPES if type(t) != type(NONE)]
-NO_INTS_NONE = [t for t in NO_INTS if type(t) != type(NONE)]
-NO_REAL = [t for t in NO_INTS if type(t) != type(FLOAT) or t in (NAN, INF, MINF)]
-NO_NUM = [t for t in NO_REAL if type(t) != type(COMPLEX)]
-ITERS = [t for t in TYPES if t in [STR, LST, TPL, DICT]]
-NO_ITERS = [t for t in TYPES if t not in ITERS]
-NO_ITERS_NONE = [t for t in NO_ITERS if type(t) != type(NONE)]
+NO_INTS = [t for t in TYPES if not isinstance(t, int)]
+NO_NONE = [t for t in TYPES if t is not None]
+NO_INTS_NONE = [t for t in NO_INTS if t is not None]
+NO_REAL = [t for t in NO_INTS if not isinstance(t, float)]
+NO_NUM = [t for t in NO_REAL if not isinstance(t, complex)]
+ITERS = [t for t in TYPES if isinstance(t, Iterable)]
+NO_ITERS = [t for t in TYPES if not isinstance(t, Iterable)]
+NO_ITERS_NONE = [t for t in NO_ITERS if t is not None]
 
 
 ################################################################################

--- a/test/noise_amplification/folding_amplifier/test_local_folding_amplifier.py
+++ b/test/noise_amplification/folding_amplifier/test_local_folding_amplifier.py
@@ -125,7 +125,7 @@ def test_set_gates_to_fold_type_error(gates_to_fold):
 
 @mark.parametrize(
     "gates_to_fold",
-    cases := [("x", True), (2, 1.0), ("h", 2, None), ("rz", 1j, 3, "i")],
+    cases := [(2, 1.0), ("h", 2, None), ("rz", 1j, 3, "i")],
     ids=[f"{c}" for c in cases],
 )
 def test_validate_gates_to_fold_type_error(gates_to_fold):

--- a/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
+++ b/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
@@ -20,7 +20,6 @@ from qiskit.circuit import CircuitInstruction, QuantumCircuit
 
 from ...utils import STANDARD_GATES
 from ...utils.docstrings import insert_into_docstring
-from ...utils.typing import isint
 from .folding_amplifier import FoldingAmplifier
 
 
@@ -113,8 +112,8 @@ class LocalFoldingAmplifier(FoldingAmplifier):
         """
         if gates_to_fold is None:
             return gates_to_fold
-        if isint(gates_to_fold) or isinstance(gates_to_fold, str):
-            gates_to_fold_set: frozenset[int | str] = frozenset((gates_to_fold,))  # type: ignore
+        if isinstance(gates_to_fold, (int, str)):
+            gates_to_fold_set: frozenset[int | str] = frozenset((gates_to_fold,))
         elif isinstance(gates_to_fold, Iterable):
             gates_to_fold_set = frozenset(gates_to_fold)
         else:
@@ -134,12 +133,12 @@ class LocalFoldingAmplifier(FoldingAmplifier):
             TypeError: If gates_to_fold contains objects that are neither int nor str.
             ValueError: If gates_to_fold contains integers smaller than one.
         """
-        if not all(isint(g) or isinstance(g, str) for g in gates_to_fold):
+        if not all(isinstance(g, (int, str)) for g in gates_to_fold):
             raise TypeError(
                 f"Expected Iterable[str | int], received {type(gates_to_fold)} instead."
             )
         for gate in gates_to_fold:
-            if isint(gate) and gate < 1:  # type: ignore
+            if isinstance(gate, int) and gate < 1:
                 raise ValueError(f"gates_to_fold contains {gate} which is smaller than one.")
             if isinstance(gate, str) and gate not in STANDARD_GATES:
                 self.warn(f"gates_to_fold contains {gate} which is not a standard gate name.")
@@ -263,7 +262,7 @@ class LocalFoldingAmplifier(FoldingAmplifier):
             TypeError: If num_foldings is not int.
             ValueError: If num_foldings is negative.
         """
-        if not isint(num_foldings):
+        if not isinstance(num_foldings, int):
             raise TypeError(f"Expected int, received {type(num_foldings)} instead.")
         if num_foldings < 0:
             raise ValueError("Number of foldings must be greater than or equal to zero.")

--- a/zne/utils/grouping.py
+++ b/zne/utils/grouping.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
-from .typing import isint
-
 
 def group_elements(elements: Sequence, group_size: int) -> list[tuple]:
     """Group elements in iterable into tuples of a given size.
@@ -45,7 +43,7 @@ def group_elements_gen(elements: Sequence, group_size: int) -> Iterator[tuple]:
     """
     if not isinstance(elements, Iterable):
         raise TypeError("Values argument must be iterable.")
-    if not isint(group_size):
+    if not isinstance(group_size, int):
         raise TypeError("Size argument must be non-zero positive int.")
     if group_size < 1:
         raise ValueError("Size argument must be non-zero positive int.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Discontinue using `isint` from typing utils module in preparation for its deprecation and removal.

