### PR TITLE
feat(utils): add normalize_array typing util

### DIFF
--- a/test/utils/test_typing.py
+++ b/test/utils/test_typing.py
@@ -12,9 +12,10 @@
 
 from test import NO_INTS, NO_REAL
 
+from numpy import array
 from pytest import mark
 
-from zne.utils.typing import isint, isinteger, isreal
+from zne.utils.typing import isint, isinteger, isreal, normalize_array
 
 
 ################################################################################
@@ -22,29 +23,66 @@ from zne.utils.typing import isint, isinteger, isreal
 ################################################################################
 @mark.parametrize("object", [0, 1, -1])
 def test_isint_true(object):
+    """Test isint true."""
     assert isint(object)
 
 
 @mark.parametrize("object", NO_INTS, ids=[str(type(i).__name__) for i in NO_INTS])
 def test_isint_false(object):
+    """Test isint false."""
     assert not isint(object)
 
 
 @mark.parametrize("object", [0, 1, -1, 1.0, -1.0])
 def test_isinteger_true(object):
+    """Test isinteger true."""
     assert isinteger(object)
 
 
 @mark.parametrize("object", [1.2, -2.4])
 def test_isinteger_false(object):
+    """Test isinteger false."""
     assert not isinteger(object)
 
 
 @mark.parametrize("object", [0, 1, -1, 1.2, -2.4])
 def test_isreal_true(object):
+    """Test isreal true."""
     assert isreal(object)
 
 
 @mark.parametrize("object", NO_REAL, ids=[str(type(i).__name__) for i in NO_REAL])
 def test_isreal_false(object):
+    """Test isreal false."""
     assert not isreal(object)
+
+
+@mark.parametrize(
+    "arr, expected",
+    [
+        (1, 1),
+        (1.0, 1.0),
+        (1j, 1j),
+        (None, None),
+        (dict(), dict()),
+        (set(), set()),
+        (list(), tuple()),
+        (tuple(), tuple()),
+        ([1], (1,)),
+        ((1,), (1,)),
+        ([1, 2], (1, 2)),
+        ((1, 2), (1, 2)),
+        ([[1, 2]], ((1, 2),)),
+        (((1, 2),), ((1, 2),)),
+        ([[1], [2]], ((1,), (2,))),
+        (([1], [2]), ((1,), (2,))),
+        (((1,), (2,)), ((1,), (2,))),
+        ([[[1]]], (((1,),),)),
+        ([[[1, 2], [3, 4]]], (((1, 2), (3, 4)),)),
+    ],
+)
+def test_normalize_array(arr, expected):
+    """Test normalize array."""
+    assert normalize_array(arr) == expected
+    arr = array(arr)
+    assert normalize_array(arr) == expected

--- a/zne/utils/typing.py
+++ b/zne/utils/typing.py
@@ -14,6 +14,8 @@
 
 from typing import Any
 
+from numpy import array
+
 
 def isint(obj: Any) -> bool:
     """Check if object is int"""
@@ -28,3 +30,17 @@ def isinteger(obj: Any) -> bool:
 def isreal(obj: Any) -> bool:
     """Check if object is a real number: int or float minus ``±Inf`` and ``NaN``."""
     return isint(obj) or isinstance(obj, float) and float("-Inf") < obj < float("Inf")
+
+
+def normalize_array(arr: Any) -> Any:
+    """Normalize array-like objects (i.e. as in numpy) to tuples of the same shape.
+
+    If zero dimensional, the object is preserved or casted to a core python type.
+    """
+    arr = array(arr)
+    num_dimensions = len(arr.shape)
+    if num_dimensions == 0:
+        return arr.tolist()
+    if num_dimensions == 1:
+        return tuple(arr.tolist())
+    return tuple(map(normalize_array, arr))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Add util to normalize array-like objects (i.e. as in numpy) to tuples of the same size. 


### Details and comments
If zero dimensional, the object is preserved or casted to core python types.
