### PR TITLE
feat(folding_amplifier): add setting to control barrier insertion

### DIFF
--- a/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
+++ b/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from test import BOOL, NO_INTS, NO_REAL, TYPES
+from test import NO_INTS, NO_REAL, TYPES
 from unittest.mock import Mock, patch
 
 from numpy.random import Generator, default_rng
@@ -145,7 +145,7 @@ class TestFoldingAmplifier:
 
     @mark.parametrize(
         "warn_user",
-        cases := [t for t in TYPES if type(t) != type(BOOL)],
+        cases := [t for t in TYPES if not isinstance(t, bool)],
         ids=[str(type(c).__name__) for c in cases],
     )
     def test_set_warn_user_type_error(self, NoiseAmplifier, warn_user):

--- a/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
+++ b/test/noise_amplification/folding_amplifier/test_folding_amplifier.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch
 
 from numpy.random import Generator, default_rng
 from pytest import fixture, mark, raises, warns
+from qiskit import QuantumCircuit
 
 from zne.noise_amplification.folding_amplifier.global_folding_amplifier import (
     GlobalFoldingAmplifier,
@@ -44,6 +45,7 @@ class TestFoldingAmplifier:
     def setter_mocks(self):
         mocks = {
             "_set_sub_folding_option": Mock(),
+            "_set_barriers": Mock(),
             "_prepare_rng": Mock(),
             "_set_noise_factor_relative_tolerance": Mock(),
         }
@@ -59,6 +61,7 @@ class TestFoldingAmplifier:
         with patch_amplifier_with_multiple_mocks(**setter_mocks):
             NoiseAmplifier()
         setter_mocks["_set_sub_folding_option"].assert_called_once_with("from_first")
+        setter_mocks["_set_barriers"].assert_called_once_with(True)
         setter_mocks["_prepare_rng"].assert_called_once_with(None)
         setter_mocks["_set_noise_factor_relative_tolerance"].assert_called_once_with(1e-2)
 
@@ -67,9 +70,13 @@ class TestFoldingAmplifier:
     ):
         with patch_amplifier_with_multiple_mocks(**setter_mocks):
             NoiseAmplifier(
-                sub_folding_option="random", random_seed=1, noise_factor_relative_tolerance=1e-1
+                sub_folding_option="random",
+                barriers=False,
+                random_seed=1,
+                noise_factor_relative_tolerance=1e-1,
             )
         setter_mocks["_set_sub_folding_option"].assert_called_once_with("random")
+        setter_mocks["_set_barriers"].assert_called_once_with(False)
         setter_mocks["_prepare_rng"].assert_called_once_with(1)
         setter_mocks["_set_noise_factor_relative_tolerance"].assert_called_once_with(1e-1)
 
@@ -146,6 +153,14 @@ class TestFoldingAmplifier:
         with raises(TypeError):
             noise_amplifier.warn_user = warn_user
 
+    @mark.parametrize(
+        "barriers", cases := [True, False, 1, 0, "", "|"], ids=[f"{c}" for c in cases]
+    )
+    def test_set_barriers(self, NoiseAmplifier, barriers):
+        noise_amplifier = NoiseAmplifier()
+        noise_amplifier._set_barriers(barriers)
+        assert noise_amplifier.barriers is bool(barriers)
+
     ################################################################################
     ## TESTS
     ################################################################################
@@ -220,3 +235,23 @@ class TestFoldingAmplifier:
     def test_compute_folding_no_foldings(self, NoiseAmplifier):
         with warns(UserWarning):
             assert NoiseAmplifier()._compute_folding_nums(3, 0) == (0, 0)
+
+    @mark.parametrize("registers", [(), (0,), (1,), (0, 1)])
+    def test_apply_barrier_true(self, NoiseAmplifier, registers):
+        circuit = QuantumCircuit(2)
+        original = circuit.copy()
+        noise_amplifier = NoiseAmplifier(barriers=True)
+        circuit = noise_amplifier._apply_barrier(circuit, *registers)
+        last_instruction = circuit.data.pop()
+        assert last_instruction.operation.name == "barrier"
+        registers = [circuit.qubits[r] for r in registers] or circuit.qubits
+        assert last_instruction.qubits == tuple(registers)
+        assert circuit == original
+
+    @mark.parametrize("registers", [(), (0,), (1,), (0, 1)])
+    def test_apply_barrier_false(self, NoiseAmplifier, registers):
+        circuit = QuantumCircuit(2)
+        original = circuit.copy()
+        noise_amplifier = NoiseAmplifier(barriers=False)
+        circuit = noise_amplifier._apply_barrier(circuit, *registers)
+        assert circuit == original

--- a/zne/noise_amplification/folding_amplifier/global_folding_amplifier.py
+++ b/zne/noise_amplification/folding_amplifier/global_folding_amplifier.py
@@ -68,7 +68,7 @@ class GlobalFoldingAmplifier(FoldingAmplifier):
                 noisy_circuit.compose(original_circuit, inplace=True)
             else:
                 noisy_circuit.compose(original_circuit.inverse(), inplace=True)
-            noisy_circuit.barrier()
+            noisy_circuit = self._apply_barrier(noisy_circuit)
         return noisy_circuit
 
     def _apply_sub_folding(
@@ -110,6 +110,6 @@ class GlobalFoldingAmplifier(FoldingAmplifier):
             instruction_idxs = sorted(self._rng.choice(len(circuit), size=size, replace=False))
             sub_data = [circuit.data[i] for i in instruction_idxs]
         for instruction, qargs, cargs in sub_data:
-            # sub_circuit.barrier(qargs)  # Note: sub-folded gates may simplify
+            # sub_circuit.barrier(qargs)  # TODO: avoid sub-folded gates simplification
             sub_circuit.append(instruction, qargs, cargs)
         return sub_circuit

--- a/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
+++ b/zne/noise_amplification/folding_amplifier/local_folding_amplifier.py
@@ -55,6 +55,7 @@ class LocalFoldingAmplifier(FoldingAmplifier):
         self,
         gates_to_fold: Sequence[int | str] | str | int | None = None,
         sub_folding_option: str = "from_first",
+        barriers: bool = True,
         random_seed: int | None = None,
         noise_factor_relative_tolerance: float = 1e-2,
         warn_user: bool = True,
@@ -63,11 +64,13 @@ class LocalFoldingAmplifier(FoldingAmplifier):
         self._set_gates_to_fold(gates_to_fold)  # TODO move to super eventually
         super().__init__(
             sub_folding_option=sub_folding_option,
+            barriers=barriers,
             random_seed=random_seed,
             noise_factor_relative_tolerance=noise_factor_relative_tolerance,
             warn_user=warn_user,
         )
 
+    # TODO: remove `insert_into_docstring`
     __init__.__doc__ = insert_into_docstring(
         FoldingAmplifier.__init__.__doc__,
         [
@@ -242,13 +245,13 @@ class LocalFoldingAmplifier(FoldingAmplifier):
         # TODO: CircuitInstruction.inverse()
         self._validate_num_foldings(num_foldings)
         instruction, qargs, cargs = operation
-        noisy_circuit.barrier(qargs)
+        noisy_circuit = self._apply_barrier(noisy_circuit, qargs)
         noisy_circuit.append(instruction, qargs, cargs)
         if num_foldings > 0:
-            noisy_circuit.barrier(qargs)
+            noisy_circuit = self._apply_barrier(noisy_circuit, qargs)
             noisy_circuit.append(instruction.inverse(), qargs, cargs)
             return self._append_folded(noisy_circuit, operation, num_foldings - 1)
-        noisy_circuit.barrier(qargs)
+        noisy_circuit = self._apply_barrier(noisy_circuit, qargs)
         return noisy_circuit
 
     @staticmethod


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds setting in `FoldingAmplifier` class and subclasses to control barrier insertion when performing the gate folding.

