### PR TITLE
Stay in qiskit 0.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dynamic = ["version", "description"]
 requires-python = ">=3.8"
 dependencies = [
-    "qiskit >= 0.45.1",
+    "qiskit >= 0.45.1,<1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Qiskit 1.0 (to be released mid-Feb 2024) wont have backwards compatibility with Qiskit `0.*` . Until a transition is done, probably makes sense to limit the dependency to `<1`.