### PR TITLE
fix(zne_estrategy): update default amplifier to multi-qubit

### DIFF
--- a/test/test_zne_strategy.py
+++ b/test/test_zne_strategy.py
@@ -22,7 +22,7 @@ from qiskit.primitives import EstimatorResult
 
 from zne.extrapolation import Extrapolator, LinearExtrapolator
 from zne.noise_amplification import NoiseAmplifier
-from zne.noise_amplification.folding_amplifier import TwoQubitAmplifier
+from zne.noise_amplification.folding_amplifier import MultiQubitAmplifier
 from zne.zne_strategy import ZNEStrategy
 
 from . import NO_ITERS_NONE, NO_NONE
@@ -68,7 +68,7 @@ class TestInit:
 
     def test_defaults(self):
         """Test default configuration."""
-        assert ZNEStrategy().noise_amplifier == TwoQubitAmplifier()
+        assert ZNEStrategy().noise_amplifier == MultiQubitAmplifier()
         assert ZNEStrategy().noise_factors == (1,)
         assert ZNEStrategy().extrapolator == LinearExtrapolator()
 
@@ -277,7 +277,7 @@ class TestNoiseAmplifier:
     def test_default(self):
         zne_strategy = ZNEStrategy()
         zne_strategy.noise_amplifier = None
-        assert zne_strategy.noise_amplifier == TwoQubitAmplifier()
+        assert zne_strategy.noise_amplifier == MultiQubitAmplifier()
 
     @mark.parametrize(
         "noise_amplifier",

--- a/zne/zne_strategy.py
+++ b/zne/zne_strategy.py
@@ -24,7 +24,7 @@ from qiskit import QuantumCircuit
 from qiskit.primitives import EstimatorResult
 
 from .extrapolation import Extrapolator, LinearExtrapolator
-from .noise_amplification import NoiseAmplifier, TwoQubitAmplifier
+from .noise_amplification import MultiQubitAmplifier, NoiseAmplifier
 from .types import EstimatorResultData, Metadata  # noqa: F401
 from .utils.grouping import from_common_key, group_elements_gen, merge_dicts
 from .utils.typing import isreal, normalize_array
@@ -120,7 +120,7 @@ class ZNEStrategy:
 
         return noise_factors
 
-    @quality(default=TwoQubitAmplifier())
+    @quality(default=MultiQubitAmplifier())
     def noise_amplifier(self, noise_amplifier: NoiseAmplifier) -> NoiseAmplifier:
         """Noise amplifier strategy for ZNE.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Update default amplifier in `ZNEStrategy` to act on all multi-qubit gates (i.e. `MultiQubitAmplifier`) instead of just two-qubit gates (i.e. `TwoQubitAmplifier`).


### Details and comments
Builds towards solving #58 
