### PR TITLE
refactor: drop BasePrimitiveResult.experiments and BasePrimitiveResult.num_experiments

### DIFF
--- a/zne/meta/job.py
+++ b/zne/meta/job.py
@@ -61,7 +61,7 @@ class ZNEJob(Job):
         result: EstimatorResult = self.base_job.result()
         if self.zne_strategy.performs_zne:
             result = self.zne_strategy.mitigate_noisy_result(result)
-        if result.num_experiments != self.target_num_experiments:
+        if len(result.values) != self.target_num_experiments:
             # TODO: consider warning instead -> should be in integration tests
             raise RuntimeError(
                 "Number of experiments in EstimatorResult object does not match "

--- a/zne/zne_strategy.py
+++ b/zne/zne_strategy.py
@@ -273,7 +273,10 @@ class ZNEStrategy:
         if len(noisy_result.values) % self.num_noise_factors != 0:
             raise ValueError("Inconsistent number of noisy experiments and noise factors.")
         for group in group_elements_gen(
-            [{'values': v, 'metadata': m} for v, m in zip(noisy_result.values, noisy_result.metadata)], 
+            [
+                {"values": v, "metadata": m}
+                for v, m in zip(noisy_result.values, noisy_result.metadata)
+            ],
             group_size=self.num_noise_factors,
         ):  # type: tuple[EstimatorResultData, ...]
             values, metadata = zip(*[data.values() for data in group])

--- a/zne/zne_strategy.py
+++ b/zne/zne_strategy.py
@@ -267,13 +267,13 @@ class ZNEStrategy:
             but same circuit-observable combinations.
 
         Raises:
-            ValueError: If the number of performed experiments is not an integer mutliple of
+            ValueError: If the number of performed experiments is not an integer multiple of
                 the number of noise factors.
         """
-        if noisy_result.num_experiments % self.num_noise_factors != 0:
+        if len(noisy_result.values) % self.num_noise_factors != 0:
             raise ValueError("Inconsistent number of noisy experiments and noise factors.")
         for group in group_elements_gen(
-            noisy_result.experiments, group_size=self.num_noise_factors
+            [ {'value': v, 'metadata': noisy_result.metadata[i]} for i,v in enumerate(noisy_result.values)], group_size=self.num_noise_factors
         ):  # type: tuple[EstimatorResultData, ...]
             values, metadata = zip(*[data.values() for data in group])
             yield EstimatorResult(values=array(values), metadata=list(metadata))
@@ -290,7 +290,7 @@ class ZNEStrategy:
         Returns:
             Regression data
         """
-        if result_group.num_experiments != self.num_noise_factors:
+        if len(result_group.values) != self.num_noise_factors:
             raise ValueError("Inconsistent number of noisy experiments and noise factors.")
         x_data = list(self.noise_factors)  # TODO: get actual noise factors achieved
         y_data = result_group.values.tolist()
@@ -316,7 +316,7 @@ class ZNEStrategy:
         """
         if extrapolation is None:
             extrapolation = {}
-        if result_group.num_experiments != self.num_noise_factors:
+        if len(result_group.values) != self.num_noise_factors:
             raise ValueError("Inconsistent number of noisy experiments and noise factors.")
         noise_amplification: Metadata = {
             "noise_amplifier": self.noise_amplifier,

--- a/zne/zne_strategy.py
+++ b/zne/zne_strategy.py
@@ -273,7 +273,8 @@ class ZNEStrategy:
         if len(noisy_result.values) % self.num_noise_factors != 0:
             raise ValueError("Inconsistent number of noisy experiments and noise factors.")
         for group in group_elements_gen(
-            [ {'value': v, 'metadata': noisy_result.metadata[i]} for i,v in enumerate(noisy_result.values)], group_size=self.num_noise_factors
+            [{'values': v, 'metadata': m} for v, m in zip(noisy_result.values, noisy_result.metadata)], 
+            group_size=self.num_noise_factors,
         ):  # type: tuple[EstimatorResultData, ...]
             values, metadata = zip(*[data.values() for data in group])
             yield EstimatorResult(values=array(values), metadata=list(metadata))


### PR DESCRIPTION
Qiskit 0.46 removes `BasePrimitiveResult.experiments` and `BasePrimitiveResult.num_experiments`. This PR moves away from those deprecated properties. 