### PR TITLE
Fix typo in tutorials/1-zne

### DIFF
--- a/docs/tutorials/1-zne.ipynb
+++ b/docs/tutorials/1-zne.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "Wait a second... the result with ZNE doesn't seem to be that good after all!\n",
     "\n",
-    "That is because on the previous run, ZNE wasn't activated. Since no `zne_strtegy` option was provided, it defaulted to the standard behavior without error mitigation. This is a design feature, not a bug: in the sake of versatility.\n",
+    "That is because on the previous run, ZNE wasn't activated. Since no `zne_strategy` option was provided, it defaulted to the standard behavior without error mitigation. This is a design feature, not a bug: in the sake of versatility.\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "    <i class=\"fas fa-info-circle\"></i>\n",


### PR DESCRIPTION
### Summary

Fix typo in `tutorials/1-zne`.

### Details and comments

I added missing 'a'.