### PR TITLE
Support for NumPy 2.x

### DIFF
--- a/zne/extrapolation/extrapolator.py
+++ b/zne/extrapolation/extrapolator.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from collections.abc import Sequence
 
 from numpy import array
-from numpy import float_ as npfloat
+from numpy import float64 as npfloat
 from numpy import isclose, mean, ndarray, ones
 
 from zne.types import Metadata


### PR DESCRIPTION
### Summary

The current code does not work with NumPy 2.x because importing float_ fails. This PR replaces float_ with float64, which is an alias for float_ and is present in both NumPy 1.x and NumPy 2.x.

### Details and comments

- [x] The current tests cover my changes. One test currently fails with or without my changes.
- [x] The documentation does not specify the NumPy version.
- [x] I have read the CONTRIBUTING document.